### PR TITLE
docs: add .env.example and README for VITE_API_BASE_URL (Droid-assisted PR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:8000/api

--- a/README.md
+++ b/README.md
@@ -95,12 +95,20 @@ A modern, responsive React frontend for the Jenga Safe rental property managemen
 ## 🔧 Configuration
 
 ### Environment Variables
-The app automatically connects to the Laravel backend at `http://localhost:8000/api`. 
+By default, the app reads `VITE_API_BASE_URL` from your environment (see `.env.example`).  
+If the variable is **not** set, it falls back to `http://localhost:8000/api`.
 
-For production, update the API base URL in `src/lib/api.ts`:
-```typescript
-const API_BASE_URL = 'https://your-api-domain.com/api';
+Set it in your `.env`:
+```bash
+VITE_API_BASE_URL=http://127.0.0.1:8000/api
 ```
+
+For production:
+```bash
+VITE_API_BASE_URL=https://your-api-domain.com/api
+```
+
+⚠️ **Do not modify `src/lib/api.ts` directly**; prefer environment variables so each environment (development, staging, production) can use its own API endpoint.
 
 ### API Integration
 The frontend uses a comprehensive API client (`src/lib/api.ts`) that handles:


### PR DESCRIPTION
Summary
- Add .env.example with VITE_API_BASE_URL defaulting to http://127.0.0.1:8000/api
- Update README to use environment variable instead of editing src/lib/api.ts directly
- Document fallback to http://localhost:8000/api when env is not set

Why
- Simplifies configuration per environment (dev/staging/prod)
- Prevents code changes for API endpoint; improves DX

Notes
- Documentation-only change; no runtime code modifications

Droid-assisted PR

---
**Factory Session:** https://app.factory.ai/sessions/EgncHQKjVT0XYFPQU0QT (created by JusticeMO)