### PR TITLE
feat(landlord): add Delegation section in Settings and fix revoke state update

### DIFF
--- a/src/components/landlord/DelegationPanel.tsx
+++ b/src/components/landlord/DelegationPanel.tsx
@@ -234,7 +234,7 @@ export function DelegationPanel() {
         });
         
         // Remove from local state
-        setDelegates(prev => prev.filter(delegate => delegate.id !== delegateToRevoke.id));
+        setDelegates(prev => prev.filter(d => d.id !== delegate.id));
       } else {
         toast({
           title: "Error",


### PR DESCRIPTION
Droid-assisted PR

What changed
- Landlord Settings now includes a Team & Delegation section that surfaces DelegationPanel
- DelegationPanel bugfix: revoke handler now updates state using the correct variable (removes revoked delegate from list)

Why
- Enables landlords to delegate management roles to property managers as discussed

Notes
- Uses existing API client methods: getDelegates, inviteDelegate, updateDelegate, revokeDelegate
- Build passes locally with Vite


---
**Factory Session:** https://app.factory.ai/sessions/EgncHQKjVT0XYFPQU0QT (created by JusticeMO)