### PR TITLE
fix(auth,cors): align payload to {email,password,role}; handle 422 gracefully; API base 127.0.0.1:8000

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 
 import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
@@ -49,7 +48,6 @@ const App = () => (
     <AuthProvider>
       <TooltipProvider>
         <Toaster />
-        <Sonner />
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/useAuth";
-import { toast } from "@/components/ui/toast";
+import { useToast } from "@/hooks/use-toast";
 import { LoginHeader } from "./login/LoginHeader";
 import { CredentialsForm } from "./login/CredentialsForm";
 
@@ -11,6 +11,7 @@ export function LoginForm() {
   const [isLoading, setIsLoading] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
+  const { toast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -22,7 +23,7 @@ export function LoginForm() {
         const lower = input.toLowerCase();
         if (lower.includes("landlord")) return "landlord";
         if (lower.includes("tenant") || lower.startsWith("07")) return "tenant";
-        return undefined; // let the API infer if we can’t
+        return undefined; // let the API infer if we can't
       };
 
       const role = inferRole(email);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -17,7 +17,16 @@ export function LoginForm() {
     setIsLoading(true);
 
     try {
-      const loggedInUser = await login(email, password);
+      // Infer role from the input for back-ends that still expect it
+      const inferRole = (input: string): "tenant" | "landlord" | undefined => {
+        const lower = input.toLowerCase();
+        if (lower.includes("landlord")) return "landlord";
+        if (lower.includes("tenant") || lower.startsWith("07")) return "tenant";
+        return undefined; // let the API infer if we can’t
+      };
+
+      const role = inferRole(email);
+      const loggedInUser = await login(email, password, role as any);
 
       if (loggedInUser) {
         toast({

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -33,10 +33,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     checkAuth();
   }, []);
 
-  const login = async (input: string, password: string): Promise<User | null> => {
+  const login = async (
+    input: string,
+    password: string,
+    role?: 'tenant' | 'landlord'
+  ): Promise<User | null> => {
     console.log("Logging in from AuthContext...");
     try {
-      const response = await apiClient.login(input, password);
+      const response = await apiClient.login(input, password, role);
       console.log("login response:", response);
       if (response.success) {
         setUser(response.user);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,7 +22,7 @@ import {
 // Allow overriding the API base URL via Vite env var. Falls back to localhost.
 // `import.meta.env` typings may vary, cast `import.meta` to any for broad compatibility.
 const API_BASE_URL =
-  (import.meta as any).env?.VITE_API_BASE_URL || "http://localhost:8000/api";
+  (import.meta as any).env?.VITE_API_BASE_URL || "http://127.0.0.1:8000/api";
 
 // API client with token management
 class ApiClient {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -238,11 +238,19 @@ class ApiClient {
   }
 
   // Auth endpoints
-  async login(input: string, password: string): Promise<ApiResponse<{ user: User; token: string }>> {
+  async login(
+    input: string,
+    password: string,
+    role?: UserRole
+  ): Promise<ApiResponse<{ user: User; token: string }>> {
     console.log("Logging in with:", { input });
     const response = await this.request<{ user: User; token: string }>('/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ input, password }),
+      body: JSON.stringify({
+        input,
+        password,
+        ...(role ? { role } : {}),
+      }),
     });
 
     // Token may be at top level (preferred) or nested in data for legacy responses

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -64,6 +64,10 @@ class ApiClient {
         credentials: 'include',
       });
 
+      // Parse JSON response before any error handling
+      const responseData = await response.json();
+      console.log(`Response from ${endpoint}:`, responseData);
+
       // Auto-logout on expired / invalid token
       if (response.status === 401) {
         this.clearToken();
@@ -72,8 +76,10 @@ class ApiClient {
         throw new Error("Unauthorized");
       }
 
-      const responseData = await response.json();
-      console.log(`Response from ${endpoint}:`, responseData);
+      // Return validation errors without throwing for 422 responses
+      if (response.status === 422) {
+        return responseData;
+      }
 
       if (!response.ok) {
         console.error(`HTTP error from ${endpoint}:`, response.status, responseData);
@@ -247,7 +253,7 @@ class ApiClient {
     const response = await this.request<{ user: User; token: string }>('/auth/login', {
       method: 'POST',
       body: JSON.stringify({
-        input,
+        email: input,
         password,
         ...(role ? { role } : {}),
       }),


### PR DESCRIPTION
Droid-assisted PR

- api.ts: request() now returns 422 validation responses instead of throwing, so forms can show field errors
- login() sends { email, password, role } to match backend and sets token on success
- Default API base: http://127.0.0.1:8000/api to avoid IPv6/host conflicts

Pairs with backend PRs:
- CORS: https://github.com/JusticeMO/jenga-safe-laravel-backend/pull/8
- Auth payload: https://github.com/JusticeMO/jenga-safe-laravel-backend/pull/9


---
**Factory Session:** https://app.factory.ai/sessions/EgncHQKjVT0XYFPQU0QT (created by JusticeMO)